### PR TITLE
プロポーザル募集終了と参加申込開始の更新

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -238,22 +238,22 @@
             </div>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-4xl mx-auto">
-            <a href="https://note.com/yukyu2nd/n/nef3ed3aae7ab?magazine_key=mf56a6e60a550" 
-               target="_blank"
-               rel="noopener noreferrer"
-               class="tech-button py-6 px-4 rounded-lg font-mono text-center h-20 flex items-center justify-center bg-amber-50 hover:bg-amber-100 border-[#fabe00] border-2 text-lg font-bold">
-                [ プロポーザル募集について ]
-            </a>
+            <button class="py-6 px-4 rounded-lg cursor-not-allowed font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 border-2 border-gray-300 text-gray-400" disabled>
+                <span class="text-lg font-bold">[ プロポーザル募集について ]</span>
+                <span class="text-sm">募集終了しました</span>
+            </button>
             <a href="https://note.com/akshimo/n/n4374853952d5?magazine_key=mf56a6e60a550" 
                target="_blank"
                rel="noopener noreferrer"
                class="tech-button py-6 px-4 rounded-lg font-mono text-center h-20 flex items-center justify-center bg-amber-50 hover:bg-amber-100 border-[#fabe00] border-2 text-lg font-bold">
                 [ スポンサー募集について ]
             </a>
-            <button class="py-4 px-4 rounded-lg cursor-not-allowed font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 border-2 border-gray-300 text-gray-400" disabled>
-                <span>[ 参加申込 ]</span>
-                <span class="text-sm">準備中...</span>
-            </button>
+            <a href="https://komekaigi.connpass.com/event/365113/" 
+               target="_blank"
+               rel="noopener noreferrer"
+               class="tech-button py-6 px-4 rounded-lg font-mono text-center h-20 flex items-center justify-center bg-amber-50 hover:bg-amber-100 border-[#fabe00] border-2 text-lg font-bold">
+                [ 参加申込 ]
+            </a>
             <button class="py-4 px-4 rounded-lg cursor-not-allowed font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 border-2 border-gray-300 text-gray-400" disabled>
                 <span>[ タイムテーブル ]</span>
                 <span class="text-sm">準備中...</span>


### PR DESCRIPTION
## Summary
- プロポーザル募集ボタンを非活性化し、募集終了の表示を追加
- 参加申込ボタンを活性化し、Connpassイベントページへのリンクを設定

## 変更内容
### プロポーザル募集について
- ボタンを非活性化（グレーアウト）
- 「募集終了しました」のテキストを追加

### 参加申込について
- ボタンを活性化
- Connpassイベントページ（https://komekaigi.connpass.com/event/365113/）へのリンクを設定
- アクティブなボタンスタイル（黄色背景、ホバー効果）を適用

## Test plan
- [x] プロポーザル募集ボタンがグレーアウトされ、クリックできないことを確認
- [x] 参加申込ボタンがアクティブで、クリックするとConnpassページが新しいタブで開くことを確認
- [x] レスポンシブデザインが維持されていることを確認（モバイル・タブレット・デスクトップ）

🤖 Generated with [Claude Code](https://claude.ai/code)