### PR TITLE
フォント統一と余白調整の改善

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -8,12 +8,41 @@
 /* ==========================================
    基本設定
    ========================================== */
+
+/* グローバルフォント設定 */
 body {
-    font-family: var(--font-primary), 'Noto Sans JP', sans-serif;
+    font-family: 'Noto Sans JP', sans-serif;
+    font-weight: 400;
+    line-height: 1.6;
+    color: #2A2E35;
 }
 
-h1, h2 {
-    font-family: var(--font-heading), 'Merriweather', serif;
+/* 見出し */
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Merriweather', 'Noto Sans JP', serif;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+/* すべてのテキスト要素に統一フォントを適用 */
+p, span, div, a, li, td, th,
+.staff-name,
+.sponsor-card-fallback,
+.modal-logo-fallback,
+.modal-info h4,
+.modal-info p,
+.modal-info a {
+    font-family: 'Noto Sans JP', sans-serif;
+}
+
+/* フォーム要素 */
+button, input, textarea, select {
+    font-family: 'Noto Sans JP', sans-serif;
+}
+
+/* コード・プリフォーマットテキスト */
+code, pre, kbd, samp {
+    font-family: 'Courier New', Courier, monospace;
 }
 
 /* スムーススクロール */
@@ -33,11 +62,23 @@ html {
     background-size: 50px 50px;
 }
 
-/* アクセントカラー */
-.accent-text {
+/* プライマリカラーテキスト */
+.text-primary {
     color: var(--color-primary);
 }
 
+/* セクションタイトル */
+.section-title {
+    color: var(--color-primary);
+    font-weight: bold;
+}
+
+/* ホバー時のプライマリカラー */
+.hover-text-primary:hover {
+    color: var(--color-primary);
+}
+
+/* アクセントボーダー */
 .accent-border {
     border: var(--border-width-2) solid var(--color-primary);
     box-shadow: var(--shadow-primary);

--- a/docs/index.html
+++ b/docs/index.html
@@ -151,7 +151,7 @@
 <section id="overview" class="py-12 md:py-16">
     <div class="container mx-auto px-4 max-w-6xl">
         <div class="card section-card mx-auto p-8 md:p-12 animate-fadeInUp">
-            <h3 class="text-3xl font-bold mb-8 text-center section-title">開催概要</h3>
+            <h3 class="text-3xl mb-8 text-center section-title">開催概要</h3>
             <div class="grid md:grid-cols-2 gap-8">
                 <div class="text-center">
                     <svg class="w-8 h-8 mx-auto mb-2 text-primary fill-none stroke-current"
@@ -182,7 +182,7 @@
 <section id="access" class="py-12 md:py-16">
     <div class="container mx-auto px-4 max-w-6xl">
         <div class="card section-card mx-auto p-8 md:p-12 animate-fadeInUp">
-            <h3 class="text-3xl font-bold mb-8 text-center section-title">アクセス</h3>
+            <h3 class="text-3xl mb-8 text-center section-title">アクセス</h3>
             
             <div class="mb-8">
                 <h4 class="text-xl font-bold mb-4 text-primary">会場</h4>
@@ -218,7 +218,7 @@
 <section id="sessions" class="py-12 md:py-16">
     <div class="container mx-auto px-4 max-w-6xl">
         <div class="text-center mb-12">
-            <h2 class="text-3xl md:text-4xl font-bold section-title">
+            <h2 class="text-3xl md:text-4xl section-title">
                 セッション
             </h2>
         </div>
@@ -241,7 +241,7 @@
 <!-- Sponsors Section -->
 <section id="sponsors" class="py-12 md:py-16 bg-amber-50">
     <div class="container mx-auto px-4 max-w-6xl">
-        <h3 class="text-3xl font-bold text-center section-title">スポンサー</h3>
+        <h3 class="text-3xl text-center section-title">スポンサー</h3>
         
         <div id="sponsors-content">
             <div class="text-center">

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
           rel="stylesheet"/>
     <!-- Tailwind CSS CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <!-- Sponsor Styles -->
+    <!-- Main Styles -->
     <link href="css/main.css" rel="stylesheet">
     <link href="css/sponsors.css" rel="stylesheet">
     <link href="css/staff.css" rel="stylesheet">
@@ -49,27 +49,27 @@
     <div class="container mx-auto flex items-center justify-between px-4">
         <a href="#hero" class="flex items-center">
             <img src="assets/images/komekaigi_symbol.svg" alt="KomeKaigi Logo" class="h-8 md:h-10 mr-2 md:mr-3"/>
-            <h1 class="text-xl md:text-2xl font-bold text-[#fabe00]">KomeKaigi 2025</h1>
+            <h1 class="text-xl md:text-2xl font-bold text-primary">KomeKaigi 2025</h1>
         </a>
         
         <!-- Desktop Navigation -->
         <nav class="hidden md:block">
             <ul class="flex space-x-6">
-                <li><a href="/about" class="hover:text-[#fabe00] transition-colors">開催趣旨</a></li>
-                <li><a href="#overview" class="hover:text-[#fabe00] transition-colors">概要</a></li>
-                <li><a href="#access" class="hover:text-[#fabe00] transition-colors">アクセス</a></li>
-                <li><a href="#sessions" class="hover:text-[#fabe00] transition-colors">セッション</a></li>
-                <li><a href="#sponsors" class="hover:text-[#fabe00] transition-colors">スポンサー</a></li>
+                <li><a href="/about" class="hover-text-primary transition-colors">開催趣旨</a></li>
+                <li><a href="#overview" class="hover-text-primary transition-colors">概要</a></li>
+                <li><a href="#access" class="hover-text-primary transition-colors">アクセス</a></li>
+                <li><a href="#sessions" class="hover-text-primary transition-colors">セッション</a></li>
+                <li><a href="#sponsors" class="hover-text-primary transition-colors">スポンサー</a></li>
                 <li><a href="https://x.com/komekaigi" target="_blank"
-                       class="hover:text-[#fabe00] transition-colors">公式X</a></li>
+                       class="hover-text-primary transition-colors">公式X</a></li>
                 <li><a href="https://note.com/komekaigi/m/mf56a6e60a550" target="_blank"
-                       class="hover:text-[#fabe00] transition-colors">公式note</a></li>
+                       class="hover-text-primary transition-colors">公式note</a></li>
             </ul>
         </nav>
         
         <!-- Mobile Menu Button -->
         <button id="mobile-menu-button" class="md:hidden p-2" aria-label="メニューを開く">
-            <svg class="w-6 h-6 text-[#fabe00] fill-none stroke-current" viewBox="0 0 24 24">
+            <svg class="w-6 h-6 text-primary fill-none stroke-current" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
             </svg>
         </button>
@@ -136,7 +136,7 @@
     <div class="container mx-auto px-4 max-w-6xl text-center">
         <div class="card section-card mx-auto p-6 md:p-8 animate-fadeInUp mb-6">
             <p class="text-lg md:text-xl mb-2">記念すべき初開催のテーマは</p>
-            <h3 class="text-2xl md:text-3xl font-bold text-[#fabe00]">「新米カンファレンス」</h3>
+            <h3 class="text-2xl md:text-3xl font-bold text-primary">「新米カンファレンス」</h3>
         </div>
         <div class="card section-card mx-auto p-5 md:p-6 animate-fadeInUp bg-amber-50">
             <p class="text-gray-700">
@@ -148,13 +148,13 @@
 </section>
 
 <!-- Overview Section -->
-<section id="overview" class="py-16 md:py-20">
+<section id="overview" class="py-12 md:py-16">
     <div class="container mx-auto px-4 max-w-6xl">
         <div class="card section-card mx-auto p-8 md:p-12 animate-fadeInUp">
-            <h3 class="text-3xl font-bold mb-8 text-center text-[#fabe00]">開催概要</h3>
+            <h3 class="text-3xl font-bold mb-8 text-center section-title">開催概要</h3>
             <div class="grid md:grid-cols-2 gap-8">
                 <div class="text-center">
-                    <svg class="w-8 h-8 mx-auto mb-2 text-[#fabe00] fill-none stroke-current"
+                    <svg class="w-8 h-8 mx-auto mb-2 text-primary fill-none stroke-current"
                          viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
@@ -165,7 +165,7 @@
                     <p class="text-xl font-medium">開志専門職大学 米山キャンパス</p>
                 </div>
                 <div class="text-center">
-                    <svg class="w-8 h-8 mx-auto mb-2 text-[#fabe00] fill-none stroke-current"
+                    <svg class="w-8 h-8 mx-auto mb-2 text-primary fill-none stroke-current"
                          viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
@@ -179,19 +179,19 @@
 </section>
 
 <!-- Access Section -->
-<section id="access" class="py-16 md:py-20">
+<section id="access" class="py-12 md:py-16">
     <div class="container mx-auto px-4 max-w-6xl">
         <div class="card section-card mx-auto p-8 md:p-12 animate-fadeInUp">
-            <h3 class="text-3xl font-bold mb-8 text-center text-[#fabe00]">アクセス</h3>
+            <h3 class="text-3xl font-bold mb-8 text-center section-title">アクセス</h3>
             
             <div class="mb-8">
-                <h4 class="text-xl font-bold mb-4 text-[#fabe00]">会場</h4>
+                <h4 class="text-xl font-bold mb-4 text-primary">会場</h4>
                 <p class="text-lg font-medium mb-2">開志専門職大学 米山キャンパス</p>
                 <p class="text-gray-600 mb-4">〒950-0916 新潟県新潟市中央区米山3丁目1-53</p>
                 
-                <h4 class="text-lg font-bold mb-2 text-[#fabe00]">交通アクセス</h4>
+                <h4 class="text-lg font-bold mb-2 text-primary">交通アクセス</h4>
                 <div class="flex items-start mb-6">
-                    <svg class="w-5 h-5 text-[#fabe00] mr-2 mt-0.5 fill-none stroke-current" viewBox="0 0 24 24">
+                    <svg class="w-5 h-5 text-primary mr-2 mt-0.5 fill-none stroke-current" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                     </svg>
                     <p>JR新潟駅南口から徒歩3分</p>
@@ -215,11 +215,11 @@
 </section>
 
 <!-- Sessions Section -->
-<section id="sessions" class="py-16 md:py-20">
+<section id="sessions" class="py-12 md:py-16">
     <div class="container mx-auto px-4 max-w-6xl">
         <div class="text-center mb-12">
-            <h2 class="text-3xl md:text-4xl font-bold">
-                <span class="accent-text">セッション</span>
+            <h2 class="text-3xl md:text-4xl font-bold section-title">
+                セッション
             </h2>
         </div>
         
@@ -239,14 +239,14 @@
 </section>
 
 <!-- Sponsors Section -->
-<section id="sponsors" class="py-16 md:py-20 bg-amber-50">
+<section id="sponsors" class="py-12 md:py-16 bg-amber-50">
     <div class="container mx-auto px-4 max-w-6xl">
-        <h3 class="text-3xl font-bold text-center text-[#fabe00]">スポンサー</h3>
+        <h3 class="text-3xl font-bold text-center section-title">スポンサー</h3>
         
         <div id="sponsors-content">
             <div class="text-center">
                 <div class="inline-block">
-                    <svg class="animate-spin h-8 w-8 text-[#fabe00] fill-none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                    <svg class="animate-spin h-8 w-8 text-primary fill-none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <circle class="opacity-25 stroke-current" cx="12" cy="12" r="10" stroke-width="4"></circle>
                         <path class="opacity-75 fill-current" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                     </svg>
@@ -272,7 +272,7 @@
 </section>
 
 <!-- Staff Section -->
-<section id="staff" class="py-16 md:py-20 bg-amber-50">
+<section id="staff" class="py-8 md:py-12 bg-amber-50">
     <div class="container mx-auto px-4 max-w-6xl">
         <div id="staff-content" class="max-w-5xl mx-auto">
             <!-- スタッフリストはJavaScriptで動的に生成 -->

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -7,8 +7,8 @@
 
     // アイコン定義
     const ICONS = {
-        MENU_OPEN: '<svg class="w-6 h-6 text-[#fabe00] fill-none stroke-current" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>',
-        MENU_CLOSE: '<svg class="w-6 h-6 text-[#fabe00] fill-none stroke-current" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>'
+        MENU_OPEN: '<svg class="w-6 h-6 text-primary fill-none stroke-current" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>',
+        MENU_CLOSE: '<svg class="w-6 h-6 text-primary fill-none stroke-current" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>'
     };
 
     /**

--- a/docs/js/sponsors.js
+++ b/docs/js/sponsors.js
@@ -170,7 +170,7 @@ function renderSponsorSection(type, config, sponsors) {
         <div class="sponsor-section-${type}">
             <div class="container mx-auto px-4${type !== 'silver' ? ' max-w-6xl' : ''}">
                 <div class="text-center mb-8">
-                    <h4 class="text-2xl font-semibold text-[#fabe00]">
+                    <h4 class="text-2xl font-semibold text-primary">
                         ${config.labelJp}
                     </h4>
                 </div>

--- a/docs/js/staff.js
+++ b/docs/js/staff.js
@@ -57,10 +57,8 @@
         }
         
         const sectionTitle = `
-            <div class="text-center mb-12">
-                <h2 class="text-3xl md:text-4xl font-bold">
-                    <span class="accent-text">スタッフ</span>
-                </h2>
+            <div class="text-center mb-8">
+                <h3 class="text-3xl font-bold section-title">スタッフ</h3>
             </div>
         `;
         
@@ -75,9 +73,9 @@
             
             return `
                 <div class="mb-12">
-                    <h3 class="text-xl md:text-2xl font-bold text-center mb-8 text-[#fabe00]">
+                    <h4 class="text-2xl font-semibold text-center mb-8 text-primary">
                         ${escapeHtml(type.name)}
-                    </h3>
+                    </h4>
                     <div class="staff-grid">
                         ${membersWithAvatar.map(member => createStaffCard(member)).join('')}
                     </div>

--- a/docs/js/staff.js
+++ b/docs/js/staff.js
@@ -58,7 +58,7 @@
         
         const sectionTitle = `
             <div class="text-center mb-8">
-                <h3 class="text-3xl font-bold section-title">スタッフ</h3>
+                <h3 class="text-3xl section-title">スタッフ</h3>
             </div>
         `;
         


### PR DESCRIPTION
## 概要
サイト全体のフォント設定を統一し、セクション間の余白を最適化しました。

## 変更内容

### 1. フォント設定の一元管理
- `main.css`でグローバルなフォント設定を管理
- スタッフとスポンサーセクションのフォントを「Noto Sans JP」に統一
- 個別CSSファイルから重複するフォント指定を削除

### 2. 余白の最適化
- セクション間の余白をコンパクトに調整
  - 通常セクション: `py-16 md:py-20` → `py-12 md:py-16`
  - スタッフセクション: `py-16 md:py-20` → `py-8 md:py-12`

### 3. カラー指定の改善
- プライマリカラー（#fabe00）をCSSクラスで管理
- 追加したクラス:
  - `.text-primary`: 基本のプライマリカラー
  - `.section-title`: セクションタイトル用
  - `.hover-text-primary`: ホバー時のカラー変更
- 個別の`text-[#fabe00]`指定をすべて削除

### 4. タイトルサイズの統一
- スタッフセクションのタイトルサイズをスポンサーと統一
- mdサイズで4xlになっていた問題を修正

## 確認項目
- [x] フォントがサイト全体で統一されている
- [x] セクション間の余白が適切である
- [x] カラー変更が`variables.css`の変更で全体に反映される
- [x] レスポンシブデザインが維持されている

🤖 Generated with [Claude Code](https://claude.ai/code)