### PR TITLE
feat: 会計協力スポンサーの表示対応

### DIFF
--- a/docs/css/sponsors.css
+++ b/docs/css/sponsors.css
@@ -49,7 +49,8 @@
 }
 
 .sponsor-card-fallback-gold,
-.sponsor-card-fallback-venue {
+.sponsor-card-fallback-venue,
+.sponsor-card-fallback-accounting {
     font-size: var(--text-2xl);
 }
 
@@ -115,7 +116,8 @@
 /* スポンサータイプ別セクション */
 .sponsor-section-gold,
 .sponsor-section-silver,
-.sponsor-section-venue {
+.sponsor-section-venue,
+.sponsor-section-accounting {
     padding: 2rem 0;
     position: relative;
 }
@@ -151,6 +153,12 @@
     max-width: var(--sponsor-container-venue-max);
 }
 
+/* 会計協力スポンサー用コンテナ */
+.sponsor-cards-accounting {
+    gap: var(--spacing-lg);
+    max-width: var(--sponsor-container-venue-max);
+}
+
 /* カードラッパーのサイズ設定 */
 .sponsor-card-wrapper.sponsor-card-gold {
     width: var(--sponsor-card-gold-width);
@@ -164,6 +172,10 @@
     width: var(--sponsor-card-venue-width);
 }
 
+.sponsor-card-wrapper.sponsor-card-accounting {
+    width: var(--sponsor-card-venue-width);
+}
+
 /* スポンサーカードの最小高さ設定 */
 .sponsor-card.sponsor-card-gold {
     min-height: 160px;
@@ -174,6 +186,10 @@
 }
 
 .sponsor-card.sponsor-card-venue {
+    min-height: 160px;
+}
+
+.sponsor-card.sponsor-card-accounting {
     min-height: 160px;
 }
 

--- a/docs/js/sponsors.js
+++ b/docs/js/sponsors.js
@@ -24,7 +24,8 @@
         SPONSOR_TYPES: {
             GOLD: { key: 'gold', label: 'GOLD', labelJp: 'ゴールドスポンサー' },
             SILVER: { key: 'silver', label: 'SILVER', labelJp: 'シルバースポンサー' },
-            VENUE: { key: 'venue', label: 'VENUE', labelJp: '会場提供' }
+            VENUE: { key: 'venue', label: 'VENUE', labelJp: '会場提供' },
+            ACCOUNTING: { key: 'accounting', label: 'ACCOUNTING', labelJp: '会計協力' }
         }
     };
 


### PR DESCRIPTION
## Summary
APIレスポンスに追加された会計協力スポンサーをWebサイトに表示できるよう対応しました。

## 変更内容
- `SPONSOR_TYPES`に会計協力（`accounting`）を追加
- 会場提供と同じサイズ・レイアウトで表示されるよう設定
- CSS: コンテナ、カードラッパー、最小高さ、フォールバック表示のスタイルを追加

## 表示仕様
- **表示位置**: 会場提供の下
- **カードサイズ**: 会場提供と同じ（`var(--sponsor-card-venue-width)`）
- **最小高さ**: 160px
- **ギャップ**: `var(--spacing-lg)`

## Test plan
- [ ] ローカル環境で会計協力スポンサーが会場提供の下に表示されることを確認
- [ ] 会場提供と同じサイズで表示されることを確認
- [ ] モーダルが正常に動作することを確認
- [ ] レスポンシブ表示が適切であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)