### PR TITLE
feat: ヒーローセクションのボタンスタイルを統一

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -107,22 +107,31 @@
             </div>
         </div>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 max-w-4xl mx-auto">
-            <button class="py-6 px-4 rounded-lg cursor-not-allowed font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 border-2 border-gray-300 text-gray-400" disabled>
-                <span class="text-lg font-bold">[ プロポーザル募集について ]</span>
-                <span class="text-sm">募集終了しました</span>
-            </button>
-            <button class="py-6 px-4 rounded-lg cursor-not-allowed font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 border-2 border-gray-300 text-gray-400" disabled>
-                <span class="text-lg font-bold">[ スポンサー募集について ]</span>
-                <span class="text-sm">募集終了しました</span>
-            </button>
-            <a href="https://komekaigi.connpass.com/event/365113/" 
+            <a href="https://note.com/yukyu2nd/n/nef3ed3aae7ab"
                target="_blank"
                rel="noopener noreferrer"
-               class="tech-button py-6 px-4 rounded-lg font-mono text-center h-20 flex items-center justify-center bg-amber-50 hover:bg-amber-100 border-[#fabe00] border-2 text-lg font-bold">
-                [ 参加申込 ]
+               class="py-6 px-4 rounded-lg font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 hover:bg-gray-200 border-2 border-gray-300 text-gray-400 transition-colors">
+                <span class="text-lg font-bold">[ プロポーザル募集について ]</span>
+                <span class="text-sm">募集終了しました</span>
             </a>
-            <a href="https://fortee.jp/komekaigi-2025/timetable" target="_blank" rel="noopener noreferrer"
-               class="tech-button py-6 px-4 rounded-lg font-mono text-center h-20 flex items-center justify-center bg-amber-50 hover:bg-amber-100 border-[#fabe00] border-2 text-lg font-bold">
+            <a href="https://note.com/akshimo/n/n4374853952d5"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="py-6 px-4 rounded-lg font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 hover:bg-gray-200 border-2 border-gray-300 text-gray-400 transition-colors">
+                <span class="text-lg font-bold">[ スポンサー募集について ]</span>
+                <span class="text-sm">募集終了しました</span>
+            </a>
+            <a href="https://komekaigi.connpass.com/event/365113/"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="py-6 px-4 rounded-lg font-mono text-center h-20 flex flex-col items-center justify-center bg-gray-100 hover:bg-gray-200 border-2 border-gray-300 text-gray-400 transition-colors">
+                <span class="text-lg font-bold">[ 参加申込 ]</span>
+                <span class="text-sm">募集終了しました</span>
+            </a>
+            <a href="https://fortee.jp/komekaigi-2025/timetable"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="py-6 px-4 rounded-lg font-mono text-center h-20 flex items-center justify-center bg-gray-100 hover:bg-gray-200 border-2 border-gray-300 text-gray-400 transition-colors text-lg font-bold">
                 [ タイムテーブル ]
             </a>
         </div>


### PR DESCRIPTION
## 概要

プロポーザル募集、スポンサー募集、参加申込、タイムテーブルのボタンを統一されたグレー背景スタイルに変更し、リンク機能を維持・復活させました。

## 変更内容

### プロポーザル募集ボタン
- ❌ 非活性の`<button disabled>` → ✅ リンク付き`<a>`に変更
- リンク先: https://note.com/yukyu2nd/n/nef3ed3aae7ab
- グレー背景 + ホバー効果を追加

### スポンサー募集ボタン
- ❌ 非活性の`<button disabled>` → ✅ リンク付き`<a>`に変更
- リンク先: https://note.com/akshimo/n/n4374853952d5
- グレー背景 + ホバー効果を追加

### 参加申込ボタン
- ❌ 黄色背景（`bg-amber-50`）→ ✅ グレー背景（`bg-gray-100`）に変更
- 「募集終了しました」テキストを追加
- リンク機能は維持（https://komekaigi.connpass.com/event/365113/）

### タイムテーブルボタン
- ❌ 黄色背景 → ✅ グレー背景に変更
- リンク機能は維持（https://fortee.jp/komekaigi-2025/timetable）

## デザイン仕様

すべてのボタンが以下の統一されたスタイルになりました：

- **背景色**: グレー（`bg-gray-100`）
- **ボーダー**: グレー（`border-gray-300`）
- **テキスト色**: グレー（`text-gray-400`）
- **ホバー効果**: 少し濃いグレー（`hover:bg-gray-200`）
- **レイアウト**: 縦方向の中央揃え（募集終了ボタンのみ2行レイアウト）

## スクリーンショット

変更前: 黄色背景のアクティブなボタンと非活性のグレーボタンが混在
変更後: 統一されたグレー背景で、すべてクリック可能

## テストプラン

- [ ] デスクトップ表示の確認
- [ ] モバイル表示の確認
- [ ] 各ボタンのリンク動作確認
- [ ] ホバー効果の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)