### PR TITLE
feat: プロポーザル募集(CfP)のリンクを公開しOPENに変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -182,13 +182,17 @@
                     </span>
                     <span class="join-arrow" aria-hidden="true">↗</span>
                 </a>
-                <div class="join-row join-row-soon">
-                    <span class="join-status join-status-soon">[ SOON ]</span>
+                <a class="join-row join-row-open"
+                   href="https://fortee.jp/komekaigi-2026/speaker/proposal/cfp"
+                   target="_blank"
+                   rel="noopener">
+                    <span class="join-status join-status-open">[ OPEN ]</span>
                     <span class="join-label">
                         <span class="join-label-title">プロポーザル募集</span>
-                        <span class="join-label-sub">準備中</span>
+                        <span class="join-label-sub">募集中</span>
                     </span>
-                </div>
+                    <span class="join-arrow" aria-hidden="true">↗</span>
+                </a>
                 <div class="join-row join-row-soon">
                     <span class="join-status join-status-soon">[ SOON ]</span>
                     <span class="join-label">

--- a/docs/index.html
+++ b/docs/index.html
@@ -183,7 +183,7 @@
                     <span class="join-arrow" aria-hidden="true">↗</span>
                 </a>
                 <a class="join-row join-row-open"
-                   href="https://fortee.jp/komekaigi-2026/speaker/proposal/cfp"
+                   href="https://note.com/pure_orca7475/n/n33f99fc0641a"
                    target="_blank"
                    rel="noopener">
                     <span class="join-status join-status-open">[ OPEN ]</span>


### PR DESCRIPTION
## 概要
トップページの JOIN US セクションで「プロポーザル募集」を [ SOON ] 準備中 から [ OPEN ] 募集中 に変更し、fortee の CfP ページへのリンクを設定しました。

## 変更内容
- `docs/index.html` の JOIN US セクション
  - プロポーザル募集の行を `div` からリンク (`a`) に変更
  - リンク先: https://note.com/pure_orca7475/n/n33f99fc0641a
  - スポンサー募集の行と同じ形式（新規タブで開く・↗ 矢印付き）に統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)