### PR TITLE
feat: プロポーザル募集をCLOSED表示に変更

### DIFF
--- a/docs/css/teaser.css
+++ b/docs/css/teaser.css
@@ -540,6 +540,18 @@ a {
     border-left-color: var(--color-primary-dark);
 }
 
+.join-row-closed {
+    padding: 1.35rem 1.25rem;
+    border-left: 3px solid rgba(42, 46, 53, 0.2);
+    transition: background 0.2s ease, border-left-color 0.2s ease;
+}
+
+.join-row-closed:hover,
+.join-row-closed:focus-visible {
+    background: rgba(42, 46, 53, 0.05);
+    border-left-color: rgba(42, 46, 53, 0.35);
+}
+
 .join-row-soon {
     padding: 1.35rem 1.25rem;
     border-left: 3px solid transparent;
@@ -566,6 +578,12 @@ a {
     color: rgba(42, 46, 53, 0.45);
 }
 
+.join-status-closed {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: rgba(42, 46, 53, 0.7);
+}
+
 .join-label {
     display: flex;
     flex-direction: column;
@@ -581,6 +599,17 @@ a {
 .join-row-open .join-label-sub {
     font-size: 0.875rem;
     color: rgba(42, 46, 53, 0.65);
+}
+
+.join-row-closed .join-label-title {
+    font-size: clamp(1rem, 2.2vw, 1.15rem);
+    font-weight: 700;
+    color: rgba(42, 46, 53, 0.72);
+}
+
+.join-row-closed .join-label-sub {
+    font-size: 0.875rem;
+    color: rgba(42, 46, 53, 0.55);
 }
 
 .join-row-soon .join-label-title {
@@ -600,8 +629,14 @@ a {
     color: var(--color-primary-dark);
 }
 
+.join-row-closed .join-arrow {
+    font-size: 1.15rem;
+    color: rgba(42, 46, 53, 0.45);
+}
+
 @media (max-width: 560px) {
-    .join-row-open {
+    .join-row-open,
+    .join-row-closed {
         gap: 0.5rem;
     }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -182,14 +182,14 @@
                     </span>
                     <span class="join-arrow" aria-hidden="true">↗</span>
                 </a>
-                <a class="join-row join-row-open"
+                <a class="join-row join-row-closed"
                    href="https://note.com/pure_orca7475/n/n33f99fc0641a"
                    target="_blank"
                    rel="noopener">
-                    <span class="join-status join-status-open">[ OPEN ]</span>
+                    <span class="join-status join-status-closed">[ CLOSED ]</span>
                     <span class="join-label">
                         <span class="join-label-title">プロポーザル募集</span>
-                        <span class="join-label-sub">募集中</span>
+                        <span class="join-label-sub">募集終了</span>
                     </span>
                     <span class="join-arrow" aria-hidden="true">↗</span>
                 </a>


### PR DESCRIPTION
## 概要

CfP（プロポーザル募集）の締切に合わせて、トップページ JOIN US セクションのプロポーザル募集行を「募集中」から「募集終了」表示に切り替えます。

## 変更内容

`docs/index.html`
- プロポーザル募集行のクラスを `join-row-open` → `join-row-closed`
- ステータス `[ OPEN ]` → `[ CLOSED ]`、サブラベル `募集中` → `募集終了`
- note の案内記事へのリンク（`href` / 矢印）は参照用に維持

`docs/css/teaser.css`
- `.join-row-closed` 系のスタイルを新設（padding・タイトル/サブのタイポグラフィは state ごとに定義されているため、OPEN/SOON と同様に closed 用も定義）
- 左ボーダーはグレー、背景ハイライトなし。hover は控えめなグレー。SOON より濃く、OPEN より抑えたトーンで「終了」と「準備中」を視覚的に区別
- 矢印は控えめなグレーに（モバイルでは既存ルールどおり非表示）
- モバイル用 `gap: 0.5rem` を closed 行にも適用

行の並び順は変更していません（`.join-row:last-child` がセクション下端のボーダーを持つため）。

## 確認

ローカルで PC（1440px）/ モバイル（390px）表示を確認済み。padding・文字サイズが隣接行と揃っており、レイアウト崩れなし。

<img width="788" height="381" alt="image" src="https://github.com/user-attachments/assets/25670e57-6102-4630-8fa4-3e257e98e75d" />


## 補足

- 検索した限り、CfP に関する記述はトップページのこの1箇所のみです（`docs/2025/` は昨年アーカイブのため対象外）。
- リンクを完全に外して `一般参加申込` と同じ非リンク行にする案もありますが、案内記事は参照価値があるためリンクを残す方針にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)